### PR TITLE
Esp smartconfig wifi provision

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+INMP441Matrix/secrets.h

--- a/INMP441Matrix/INMP441Matrix.ino
+++ b/INMP441Matrix/INMP441Matrix.ino
@@ -190,6 +190,7 @@ void loop() {
   
   FastLED.setBrightness(brightness);
   FastLED.show();
+  delay(1);
 
   ws.cleanupClients();
 }
@@ -259,6 +260,7 @@ void showIP(){
 
   while(ScrollingMsg.UpdateText() == 0) {
     FastLED.show();  
+    delay(1);
   }
 }
 


### PR DESCRIPTION
I added the ability to use the ESP Touch Smartconfig App for wifi provisioning.  This method of connection also  significantly speeds up subsequent hardcoded wifi boot times since it attempts to reconnect to any previously connected AP's stored in the esp own wifi credential memory.  The first boot does take about 30 seconds longer due to the smartconfig attempt followed by the hard code connection attempts.  Later feature in this this vein might be more display feedback during smartconfig process.